### PR TITLE
Put netlink fd behind an epoll fd

### DIFF
--- a/libtcmu_priv.h
+++ b/libtcmu_priv.h
@@ -39,6 +39,7 @@ struct tcmulib_context {
 	darray(struct tcmu_device*) devices;
 
 	struct nl_sock *nl_sock;
+	int epoll_fd;
 
 	void (*err_print)(const char *fmt, ...);
 };


### PR DESCRIPTION
As mentioned in #43, we're going to be adding DBus support in libtcmu and
will need additional FDs, but we still want the client to just have to
deal with 1 master fd for us, so hide them behind an epollfd.

This patch just puts the one netlink fd behind the one epoll fd, so kind
of pointless but good to examine separately from the following DBus
changes.

Using epoll_create1() with CLOEXEC for no particular reason, it's just
usually better to set this, I'm led to believe.

Signed-off-by: Andy Grover <agrover@redhat.com>